### PR TITLE
feat: Script별 webpack분리 및 경로 수정, NPM배포

### DIFF
--- a/bin/react-scripts-lite.js
+++ b/bin/react-scripts-lite.js
@@ -18,4 +18,6 @@ if (!script) {
   process.exit(1);
 }
 
-const result = spawnSync("node", [`../react-scripts-lite/scripts/${script}.js`]);
+const result = spawnSync("node", [
+  path.resolve(__dirname, `../scripts/${script}.js`),
+]);

--- a/config/env.js
+++ b/config/env.js
@@ -1,7 +1,0 @@
-const fs = require("fs");
-const path = require("path");
-
-const env = fs.readFileSync(path.join(__dirname, "../../../.env")).toString();
-const envOption = {};
-
-module.exports = envOption;

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -86,9 +86,7 @@ module.exports = (node_env) => {
       new MiniCssExtractPlugin({
         filename: "static/css/[name].css",
       }),
-      new dotenv({
-        // path: path.resolve(__dirname, "/.env")
-      }),
+      new dotenv({}),
     ],
   };
 };

--- a/config/webpackDevServer.config.js
+++ b/config/webpackDevServer.config.js
@@ -11,10 +11,10 @@ module.exports = (node_env) => {
     target: "web",
     mode: isDevEnv ? "development" : isProdEnv && "production",
     entry: {
-      index: path.resolve(__dirname, "../../../src/index.jsx"),
+      index: path.join("/src/index.jsx"),
     },
     output: {
-      path: path.resolve(__dirname, "../../../build"),
+      path: path.join("/build"),
       filename: "static/js/[name].js",
       assetModuleFilename: "static/media/[name][ext]",
     },
@@ -79,16 +79,23 @@ module.exports = (node_env) => {
         },
       ],
     },
+    devServer: {
+      port: "3000",
+      static: {
+        directory: path.join("/public"),
+      },
+      allowedHosts: ["all"],
+      open: true,
+      liveReload: true,
+    },
     plugins: [
       new HtmlWebpackPlugin({
-        template: path.resolve(__dirname, "../../../public/index.html"),
+        template: path.join("/public", "index.html"),
       }),
       new MiniCssExtractPlugin({
         filename: "static/css/[name].css",
       }),
-      new dotenv({
-        // path: path.resolve(__dirname, "/.env")
-      }),
+      new dotenv(),
     ],
   };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-scripts-lite",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-scripts-lite",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "dotenv-webpack": "^8.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-scripts-lite",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-scripts-lite",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "dotenv-webpack": "^8.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-scripts-lite",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-scripts-lite",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "dotenv-webpack": "^8.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "dotenv-webpack": "^8.0.0",
-        "fs": "^0.0.1-security",
         "html-webpack-plugin": "^5.5.0",
         "jest": "^28.1.2",
         "mini-css-extract-plugin": "^2.6.1",
@@ -2610,11 +2609,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/fs": {
-      "version": "0.0.1-security",
-      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
-      "integrity": "sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w=="
     },
     "node_modules/fs-monkey": {
       "version": "1.0.3",
@@ -7747,11 +7741,6 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="
-    },
-    "fs": {
-      "version": "0.0.1-security",
-      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
-      "integrity": "sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w=="
     },
     "fs-monkey": {
       "version": "1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-scripts-lite",
-  "version": "1.1.0",
+  "version": "1.2.0-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-scripts-lite",
-      "version": "1.1.0",
+      "version": "1.2.0-0",
       "license": "MIT",
       "dependencies": {
         "dotenv-webpack": "^8.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-scripts-lite",
-  "version": "1.2.0-0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-scripts-lite",
-      "version": "1.2.0-0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "dotenv-webpack": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "homepage": "https://github.com/eggfreitag/react-scripts-lite#readme",
   "dependencies": {
     "dotenv-webpack": "^8.0.0",
-    "fs": "^0.0.1-security",
     "html-webpack-plugin": "^5.5.0",
     "jest": "^28.1.2",
     "mini-css-extract-plugin": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-scripts-lite",
-  "version": "1.1.0",
+  "version": "1.2.0-0",
   "description": "Configuration of webpack and scripts for Create-React-App-Lite",
   "bin": {
     "react-scripts-lite": "./bin/react-scripts-lite.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-scripts-lite",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Configuration of webpack and scripts for Create-React-App-Lite",
   "bin": {
     "react-scripts-lite": "./bin/react-scripts-lite.js"

--- a/package.json
+++ b/package.json
@@ -1,13 +1,9 @@
 {
   "name": "react-scripts-lite",
-  "version": "1.0.0",
-  "description": "react-scripts-lite",
-  "main": "./bin/react-scripts-lite.js",
+  "version": "1.0.1",
+  "description": "Configuration of webpack and scripts for Create-React-App-Lite",
   "bin": {
     "react-scripts-lite": "./bin/react-scripts-lite.js"
-  },
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-scripts-lite",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Configuration of webpack and scripts for Create-React-App-Lite",
   "bin": {
     "react-scripts-lite": "./bin/react-scripts-lite.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-scripts-lite",
-  "version": "1.2.0-0",
+  "version": "1.0.1",
   "description": "Configuration of webpack and scripts for Create-React-App-Lite",
   "bin": {
     "react-scripts-lite": "./bin/react-scripts-lite.js"

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -5,7 +5,7 @@ process.on("unhandledRejection", (err) => {
 const webpack = require("webpack");
 const WebpackDevServer = require("webpack-dev-server");
 
-const configFactory = require("../config/webpack.config.js");
+const configFactory = require("../config/webpackDevServer.config");
 const webpackConfig = configFactory("development");
 const compiler = webpack(webpackConfig);
 const devServerOptions = { ...webpackConfig.devServer };


### PR DESCRIPTION
# **Description**
<img width="800" alt="image" src="https://user-images.githubusercontent.com/93723399/178745437-2d57e117-8a34-4825-a83e-c24f4f4cefad.png">

-  `Create-react-app-lite`에서 `build`와 `start`를 `script`로 분리하여 `webpack dev server`실행과 `compiling`을 할 수 있도록 작성했고 NPM에 배포 완료했습니다.